### PR TITLE
fix: outdated faq

### DIFF
--- a/public_html/faq.html
+++ b/public_html/faq.html
@@ -18,7 +18,7 @@
         <div class="post">
             <h3>Is this multiplayer patch for Crysis Remastered?</h3>
             <div class="answ">
-                No, Crysis Remastered is a separate game that has no multiplayer. This patch is related to original Crysis 1 from 2008
+                No, Crysis Remastered is a separate game that has no multiplayer. This patch is related to original Crysis 1 from 2007
             </div>
         </div>
         <div class="post">
@@ -31,9 +31,8 @@
         <div class="post">
             <h3>When I open internet game, I see GameSpy login screen</h3>
             <div class="answ">
-                <div>First of all, <b>check whether you are running correct game version</b>, you can do so by looking into bottom right corner, there should be some number like 1.1.5767 or 1.1.6115 or 1.1.6156. <b>The required version to use CryMP client is 6156</b>. </div>
-                <div>If your game version is 6156 and you still see GameSpy log-in screen, <b>make sure you are launching the game using shortcut generated on the Desktop by installer</b>. </div>
-                <div>If you don't have any shortcuts on your Desktop, just run installer once again or launch the game with -mod sfwcl argument</div>
+                <div>Make sure you are launching the game using the Crysis Multiplayer shortcut on your Desktop.</div>
+                <div>If you don't have the shortcut, go to Crysis folder and run CryMP-Launcher directly.</div>
             </div>
         </div>
         <div class="post">
@@ -55,12 +54,6 @@
                     </li>
                 </ul>
                 <strong>In order for it to work, you must install Patch 1.2 first, and then install Patch 1.2.1</strong>
-            </div>
-        </div>
-        <div class="post">
-            <h3>I have AMD CPU and my game is crashing</h3>
-            <div class="answ">
-                <div>Make sure you are launching <b>game.exe</b> installed by installer and not Crysis.exe or Crysis64.exe when running the game. </div>
             </div>
         </div>
         <div class="post">


### PR DESCRIPTION
- the first Crysis release was in 2007
- the client checks game version and eventually shows an error message saying what to do
- `-mod sfwcl` is no longer used
- AMD CPU crash fix is always there because the client is EXE now