### PR TITLE
Replace deprecated nullptr.one domains with crymp.org

### DIFF
--- a/public_html/faq.html
+++ b/public_html/faq.html
@@ -47,10 +47,10 @@
             <div class="answ">For some reason, Crytek doesn't provide patch downloads on their website anymore, but you can download them here: <br>
                 <ul>
                     <li>
-                        <a href="https://crysis.nullptr.one/Crysis_Patch_1_2.exe" rel="nofollow">Patch 1.2</a>
+                        <a href="https://comrade.one/Crysis_Patch_1_2.exe" rel="nofollow">Patch 1.2</a>
                     </li>
                     <li>
-                        <a href="https://crysis.nullptr.one/Crysis_Patch_1_2_1.exe" rel="nofollow">Patch 1.2.1</a>
+                        <a href="https://comrade.one/Crysis_Patch_1_2_1.exe" rel="nofollow">Patch 1.2.1</a>
                     </li>
                 </ul>
                 <strong>In order for it to work, you must install Patch 1.2 first, and then install Patch 1.2.1</strong>

--- a/web_api.lua
+++ b/web_api.lua
@@ -778,14 +778,14 @@ function api:getReleaseByCommit(release_type, commit)
                         arch = 32,
                         hash = result.hash32,
                         path = "CryMP-Client32.exe",
-                        url = "https://crymp.nullptr.one/static/releases/" .. result.commit .. "/CryMP-Client32.exe"
+                        url = "https://crymp.org/static/releases/" .. result.commit .. "/CryMP-Client32.exe"
                     },
                     {
                         type = "exe",
                         arch = 64,
                         hash = result.hash64,
                         path = "CryMP-Client64.exe",
-                        url = "https://crymp.nullptr.one/static/releases/" .. result.commit .. "/CryMP-Client64.exe"
+                        url = "https://crymp.org/static/releases/" .. result.commit .. "/CryMP-Client64.exe"
                     }
                 }
             })


### PR DESCRIPTION
There is a way to bypass the Internet censorship in Russia without a VPN. However, a list of domains is needed. CryMP client updates did not work with only `crymp.org` on the list. This is now fixed by replacing the deprecated `crymp.nullptr.one` domain with `crymp.org`.

Thanks to MAIKI_FG for bringing this up!